### PR TITLE
Update to Raspbian Jessie and GCC 4.8.3

### DIFF
--- a/Customfile
+++ b/Customfile
@@ -1,0 +1,4 @@
+config.vm.provider "virtualbox" do |v|
+  v.memory = 3072
+  v.cpus = 4
+end

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Raspberry Pi Devbox
 
-A [Vagrant](http://vagrantup.com) recipe for an Ubuntu 12.04 virtual machine, intented to make C/C++ development for Raspberry Pi a less painful experience. This is a fork of <https://github.com/Asquera/raspberry-devbox>.
+A [Vagrant](http://vagrantup.com) recipe for an Ubuntu 12.04 virtual machine, intented to make C/C++ development for Raspberry Pi a less painful experience. Forked from <https://github.com/nickhutchinson/raspberry-devbox>, updated to use a Raspbian 8 Jessie chroot and the latest [Raspberry Pi cross-compiler toolchain (gcc 4.8.3)](https://github.com/raspberrypi/tools).
 
 This VM includes a sandboxed installation ("chroot") of [Raspbian](http://www.raspbian.org), an ARM variant of the Debian Linux distribution optimized for Raspberry Pi. Use of the sandbox is mediated by a cross-compiling tool called [ScratchBox2](http://maemo.gitorious.org/scratchbox2). ScratchBox2 craftily translates the ARM executables bundled with Raspbian such that they run on your Intel box.
 
 Why is this so nice? Suppose you have C++ app that you want to build for the Raspberry Pi, but it requires a bunch of third-party libraries. Do you really want to hunt down these libraries, their dependencies, their dependencies dependencies, their dependencies dependencies dependencies and so on, until you're able to build your own app? It should be clear that that way lies madness. Perhaps you'll just copy the headers and libraries from your Raspberry to your Intel box, and point your compiler at those. That might work, but it'll be fragile and annoying.
 
 How about we let the Raspbian folks do all the hard work? With ScratchBox2, you can simply apt-get to your heart's content. Just type:
-        
+
         sb2 -eR apt-get install ...
 
 This executes `apt-get` in the default ScratchBox2 container (in our case, we only have the one. It's called "raspberry".) The `-e` flag is for chroot (emulated) mode; `-R` runs the command as the equivalent of *root* in the sandboxed environment. For a slightly more thorough explanation of ScratchBox2, see these presentation slides: <http://www.daimi.au.dk/~cvm/sb2.pdf>.
@@ -20,16 +20,28 @@ This executes `apt-get` in the default ScratchBox2 container (in our case, we on
 
 Vagrant will now download the basebox, bootstrap the environment and run the provisioner for the first time. Since the basebox and numerous packages must be downloaded, the first run may take some time depending on your network connection. No supervision should be required; running the install overnight should be just fine. Future runs will be much faster, and won't require network connectivity.
 
-If like to see words dribble down your screen, you can monitor the bootstrap progress by running `vagrant ssh` to ssh into your VM, and then `tail -F ~/raspberry-dev/rootfs/debootstrap/debootstrap.log`)
+If like to see words dribble down your screen, you can monitor the bootstrap progress by running `vagrant ssh` to ssh into your VM, and then `tail -F ~/raspberry-dev/rootfs/debootstrap/debootstrap.log`
 
 After installation has completed, you should find:
 
 - In `~/raspberry-dev/rootfs`
     - the [Raspbian](http://www.raspbian.org) chroot.
 - In `/opt/raspberry-dev`
-    - the official [GCC 4.7.2 cross-compiler toolchain](https://github.com/raspberrypi/tools): `arm-linux-gnueabihf-gcc`, `arm-linux-gnueabihf-ld` and so on.
+    - the official [GCC 4.8.3 cross-compiler toolchain](https://github.com/raspberrypi/tools): `arm-linux-gnueabihf-gcc`, `arm-linux-gnueabihf-ld` and so on.
     - [QEmu](http://wiki.qemu.org/Main_Page) 1.3.0
     - [ScratchBox2](http://maemo.gitorious.org/scratchbox2) @ git tag 2.3.90 (earlier releases didn't seem to work)
+
+The default configuration allocates 4 CPU cores and 4 GB of RAM to the VM. This can be configured by editing the following lines in the `Vagrantfile`:
+
+    v.memory = 4096
+    v.cpus = 4
+
+## Example Usage
+
+* Starting the VM: in the program root directory, run `vagrant up` to start the VM, then `vagrant ssh` to enter it.
+* `sb2 make` make using host cross compiler toolchain.
+* `sb2 -e make` make using emulated target toolchain.
+* `sb2 -eR make install` install in emulation mode as root.
 
 ## VirtualBox
 
@@ -50,11 +62,5 @@ The basic virtualization layer is [VirtualBox](https://www.virtualbox.org). Any 
 
 Provisioning of the Virtual Machine is handled by [Puppet](http://puppetlabs.com). Take a look at the `raspberry_dev` module.
 
-## Bugs, fixes, improvements
-
-If you encounter a problem, please file a ticket. If you can help improve this Virtual Machine recipe please let me know; I'm very new to Vagrant, Puppet, ScratchBox2 and Raspberry Pi, and barely know what I'm doing!
-
-## Todo
-
-* all of this is still quite rough
-* improve on the readme
+## Bugs
+* Some programs such as aptitude crash with segfault when run in emulation mode. Updated qemu might fix this

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,3 +26,12 @@ Vagrant::Config.run do |config|
     end
   end
 end
+
+Vagrant.configure("2") do |config|
+  
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 4096
+    v.cpus = 4
+  end
+
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant::Config.run do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.define :nox do |box|
+  config.vm.define :nox1 do |box|
     # Every Vagrant virtual environment requires a box to build off of.
     box.vm.box = "precise64"
     # The url from where the 'config.vm.box' box will be fetched if it

--- a/modules/raspberry_dev/files/rootfs/etc/apt/sources.list
+++ b/modules/raspberry_dev/files/rootfs/etc/apt/sources.list
@@ -1,2 +1,2 @@
-deb http://archive.raspbian.org/raspbian/ wheezy main contrib non-free rpi
-deb-src http://archive.raspbian.org/raspbian/ wheezy main contrib non-free rpi
+deb http://archive.raspbian.org/raspbian/ jessie main contrib non-free rpi
+deb-src http://archive.raspbian.org/raspbian/ jessie main contrib non-free rpi

--- a/modules/raspberry_dev/manifests/packages.pp
+++ b/modules/raspberry_dev/manifests/packages.pp
@@ -1,6 +1,6 @@
 class raspberry_dev::packages {
   $required_packages = ['libncurses5', 'fakeroot', 'debootstrap', 'curl',
-    'libstdc++6:i386', 'zlib1g:i386', 'libc6-dev-i386', 'build-essential']
+    'libstdc++6:i386', 'zlib1g:i386', 'libc6-dev-i386', 'build-essential', 'git']
 
   package {$required_packages:
     ensure  => installed,

--- a/modules/raspberry_dev/manifests/raspbian_chroot.pp
+++ b/modules/raspberry_dev/manifests/raspbian_chroot.pp
@@ -29,7 +29,9 @@ class raspberry_dev::raspbian_chroot {
   } -> exec {'raspbian-install-key':
     command => 'curl http://archive.raspbian.org/raspbian.public.key | apt-key add -',
     unless  => 'apt-key list | grep "Raspberry Pi Debian"'
-
+  } -> exec {'fix-debootstrap-script':
+    command => 'ln -s /usr/share/debootstrap/scripts/sid /usr/share/debootstrap/scripts/jessie',
+    unless => 'ls /usr/share/debootstrap/scripts | grep jessie'
   } -> exec {'debootstrap-first-stage':
     command => $bootstrap_cmd,
     environment => $sbox2_required_env_flags,

--- a/modules/raspberry_dev/manifests/raspbian_chroot.pp
+++ b/modules/raspberry_dev/manifests/raspbian_chroot.pp
@@ -11,7 +11,7 @@ class raspberry_dev::raspbian_chroot {
 
   $bootstrap_cmd = 
       "fakeroot debootstrap --verbose --foreign --variant=scratchbox \
-        --arch armhf --keyring /etc/apt/trusted.gpg wheezy \
+        --arch armhf jessie \
         ${raspberry_dev::config::sbox2_container_path} ${raspbian_mirror}"
 
   # without this, sbox2 sees HOME as "/root" for some reason, and all sb2 

--- a/modules/raspberry_dev/manifests/toolchain.pp
+++ b/modules/raspberry_dev/manifests/toolchain.pp
@@ -1,15 +1,13 @@
 class raspberry_dev::toolchain {
-  $toolchain_url = 'http://commondatastorage.googleapis.com/howling-fantods/raspberrypi/raspberry-gcc-toolchain_1.0_i386.deb'
-  $toolchain_deb_filename = 'raspberry-gcc-toolchain_1.0_i386.deb'
+  $toolchain_url = 'https://github.com/raspberrypi/tools'
 
   exec {'download-toolchain':
-    command => "curl -L ${toolchain_url} -o ${toolchain_deb_filename}",
+    command => "git clone ${toolchain_url}",
     cwd => $raspberry_dev::config::debs_dir,
-    creates => "${raspberry_dev::config::debs_dir}/${toolchain_deb_filename}"
-
-  } -> package {'raspberry-gcc-toolchain': 
-    provider => dpkg, 
-    ensure => installed, 
-    source => "${raspberry_dev::config::debs_dir}/${toolchain_deb_filename}"
-  } 
+    creates => "${raspberry_dev::config::debs_dir}/tools"
+  } -> exec {'install-toolchain':
+    command => "cp -r arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/* \
+                ${raspberry_dev::config::tools_prefix}",
+    cwd => "${raspberry_dev::config::debs_dir}/tools"
+  }
 }


### PR DESCRIPTION
* Raspbian chroot updated to Jessie
* GCC toolchain is now installed directly from the official [Raspberry Pi repo](https://github.com/raspberrypi/tools) and should always be up to date